### PR TITLE
Tempo meta event check fix

### DIFF
--- a/src/QMidiFile.cpp
+++ b/src/QMidiFile.cpp
@@ -235,7 +235,7 @@ void QMidiFile::addEvent(qint32 tick, QMidiEvent* e)
 {
 	e->setTick(tick);
 	fEvents.append(e);
-	if ((e->track() == 0) && (e->number() == QMidiEvent::Tempo)) {
+	if ((e->track() == 0) && (e->type() == QMidiEvent::Meta) && (e->number() == QMidiEvent::Tempo)) {
 		fTempoEvents.append(e);
 	}
 	sort();
@@ -243,7 +243,7 @@ void QMidiFile::addEvent(qint32 tick, QMidiEvent* e)
 void QMidiFile::removeEvent(QMidiEvent* e)
 {
 	fEvents.removeOne(e);
-	if ((e->track() == 0) && (e->number() == QMidiEvent::Tempo)) {
+	if ((e->track() == 0) && (e->type() == QMidiEvent::Meta) && (e->number() == QMidiEvent::Tempo)) {
 		fTempoEvents.removeOne(e);
 	}
 }


### PR DESCRIPTION
There is an array named fTempoEvents which should contain only Set Tempo
meta events. But because of missing check, it can also contain other
events (basically any event with second byte equal to 0x51). The fix is
related to issue #3 

@waddlesplash 
