### PR TITLE
Track format check

### DIFF
--- a/src/QMidiFile.cpp
+++ b/src/QMidiFile.cpp
@@ -841,6 +841,7 @@ bool QMidiFile::load(QString filename)
 		} else {
 			in.close();
             		disableSort = false;
+            		sort();
             		return false;
 		}
 

--- a/src/QMidiFile.cpp
+++ b/src/QMidiFile.cpp
@@ -838,6 +838,10 @@ bool QMidiFile::load(QString filename)
 			}
 
 			number_of_tracks_read++;
+		} else {
+			in.close();
+            		disableSort = false;
+            		return false;
 		}
 
 		/* forwards compatibility: skip over any unrecognized chunks, or extra


### PR DESCRIPTION
If midi file has wrong track format at some point than load function stucks in indefinite loop where this condition is always true...
while (number_of_tracks_read < number_of_tracks)

It is related to issue #5 
