### PR TITLE
Add QMidiIn class + allow sending/receiving System Exclusive messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ compiler: clang
 addons:
   apt:
     packages:
-    - libqt4-dev
+    - qt5-default
+    - qt5-qmake
     - libasound2-dev
 install:
  - cd examples/qtplaysmf/
 script:
- - qmake -spec unsupported/linux-clang .
+ - qmake --version
+ - qmake .
  - make

--- a/src/OS/QMidi_ALSA.cpp
+++ b/src/OS/QMidi_ALSA.cpp
@@ -3,13 +3,16 @@
  * All rights reserved. Distributed under the terms of the MIT license.
  */
 #include "QMidiOut.h"
+#include "QMidiIn.h"
+#include "OS/QMidi_ALSA.h"
 
+#include <QByteArray>
 #include <QStringList>
 #include <alsa/asoundlib.h>
 #include <alsa/seq.h>
 #include <alsa/seq_midi_event.h>
 
-/* -----------------------------[ QMidiOut ]------------------------------ */
+// # pragma mark - QMidiOut
 
 struct NativeMidiOutInstances {
 	snd_seq_t* midiOutPtr;
@@ -65,8 +68,7 @@ bool QMidiOut::connect(QString outDeviceId)
 	fMidiPtrs = new NativeMidiOutInstances;
 
 	int err = snd_seq_open(&fMidiPtrs->midiOutPtr, "default", SND_SEQ_OPEN_OUTPUT, 0);
-	if (err < 0)
-	{
+	if (err < 0) {
 		delete fMidiPtrs;
 		return false;
 	}
@@ -132,227 +134,205 @@ void QMidiOut::sendMsg(qint32 msg)
 
 void QMidiOut::sendSysEx(const QByteArray &data)
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    snd_seq_event_t ev;
-    snd_midi_event_t* mev;
+	snd_seq_event_t ev;
+	snd_midi_event_t* mev;
 
-    snd_seq_ev_set_source(&ev, 0);
-    snd_seq_ev_set_subs(&ev);
-    snd_seq_ev_set_direct(&ev);
+	snd_seq_ev_set_source(&ev, 0);
+	snd_seq_ev_set_subs(&ev);
+	snd_seq_ev_set_direct(&ev);
 
-    snd_midi_event_new(data.size(), &mev);
-    snd_midi_event_resize_buffer(mev, data.size());
-    snd_midi_event_encode(mev, (unsigned char*) data.data(), data.size(), &ev);
+	snd_midi_event_new(data.size(), &mev);
+	snd_midi_event_resize_buffer(mev, data.size());
+	snd_midi_event_encode(mev, (unsigned char*) data.data(), data.size(), &ev);
 
-    snd_seq_event_output(fMidiPtrs->midiOutPtr, &ev);
-    snd_seq_drain_output(fMidiPtrs->midiOutPtr);
+	snd_seq_event_output(fMidiPtrs->midiOutPtr, &ev);
+	snd_seq_drain_output(fMidiPtrs->midiOutPtr);
 
-    snd_midi_event_free(mev);
+	snd_midi_event_free(mev);
 }
 
-/* ------------------------------[ QMidiIn ]------------------------------ */
-
-#include "QMidiIn.h"
-#include <QByteArray>
-
-#include "OS/QMidi_ALSA.h"
+// # pragma mark - QMidiIn
 
 struct NativeMidiInInstances {
-    //!
-    //! \brief midiIn is a reference to the MIDI input device
-    //!
-    snd_seq_t* midiIn;
+	//! \brief midiIn is a reference to the MIDI input device
+	snd_seq_t* midiIn;
 
-    //!
-    //! \brief receiveThread is a reference to the MIDI input receive thread.
-    //!
-    MidiInReceiveThread* receiveThread;
+	//! \brief receiveThread is a reference to the MIDI input receive thread.
+	MidiInReceiveThread* receiveThread;
 };
 
 QMap<QString, QString> QMidiIn::devices()
 {
-    QMap<QString, QString> ret;
+	QMap<QString, QString> ret;
 
-    snd_seq_client_info_t* cinfo;
-    snd_seq_port_info_t* pinfo;
-    int client;
-    int err;
-    snd_seq_t* handle;
+	snd_seq_client_info_t* cinfo;
+	snd_seq_port_info_t* pinfo;
+	int client;
+	int err;
+	snd_seq_t* handle;
 
-    err = snd_seq_open(&handle, "hw", SND_SEQ_OPEN_INPUT, 0);
-    if (err < 0) {
-        /* Use snd_strerror(errno) to get the error here. */
-        return ret;
-    }
+	err = snd_seq_open(&handle, "hw", SND_SEQ_OPEN_INPUT, 0);
+	if (err < 0) {
+		/* Use snd_strerror(errno) to get the error here. */
+		return ret;
+	}
 
-    snd_seq_client_info_alloca(&cinfo);
-    snd_seq_client_info_set_client(cinfo, -1);
+	snd_seq_client_info_alloca(&cinfo);
+	snd_seq_client_info_set_client(cinfo, -1);
 
-    while (snd_seq_query_next_client(handle, cinfo) >= 0) {
-        client = snd_seq_client_info_get_client(cinfo);
-        snd_seq_port_info_alloca(&pinfo);
-        snd_seq_port_info_set_client(pinfo, client);
+	while (snd_seq_query_next_client(handle, cinfo) >= 0) {
+		client = snd_seq_client_info_get_client(cinfo);
+		snd_seq_port_info_alloca(&pinfo);
+		snd_seq_port_info_set_client(pinfo, client);
 
-        snd_seq_port_info_set_port(pinfo, -1);
-        while (snd_seq_query_next_port(handle, pinfo) >= 0) {
-            int cap = (SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_READ);
-            if ((snd_seq_port_info_get_capability(pinfo) & cap) == cap) {
-                QString port = QString::number(snd_seq_port_info_get_client(pinfo));
-                port += ":" + QString::number(snd_seq_port_info_get_port(pinfo));
-                QString name = snd_seq_client_info_get_name(cinfo);
-                ret.insert(port, name);
-            }
-        }
-    }
+		snd_seq_port_info_set_port(pinfo, -1);
+		while (snd_seq_query_next_port(handle, pinfo) >= 0) {
+			int cap = (SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_READ);
+			if ((snd_seq_port_info_get_capability(pinfo) & cap) == cap) {
+				QString port = QString::number(snd_seq_port_info_get_client(pinfo));
+				port += ":" + QString::number(snd_seq_port_info_get_port(pinfo));
+				QString name = snd_seq_client_info_get_name(cinfo);
+				ret.insert(port, name);
+			}
+		}
+	}
 
-    snd_seq_close(handle);
+	snd_seq_close(handle);
 
-    return ret;
+	return ret;
 }
 
 bool QMidiIn::connect(QString inDeviceId)
 {
-    if (fConnected)
-    {
-        disconnect();
-    }
+	if (fConnected)
+		disconnect();
 
-    fMidiPtrs = new NativeMidiInInstances;
-    int err = snd_seq_open(&fMidiPtrs->midiIn, "default", SND_SEQ_OPEN_INPUT, 0);
-    if (err < 0)
-    {
-        delete fMidiPtrs;
-        return false;
-    }
-    snd_seq_set_client_name(fMidiPtrs->midiIn, "QMidi");
-    snd_seq_create_simple_port(fMidiPtrs->midiIn, "Input Port", SND_SEQ_PORT_CAP_WRITE,
-                               SND_SEQ_PORT_TYPE_MIDI_GENERIC);
+	fMidiPtrs = new NativeMidiInInstances;
+	int err = snd_seq_open(&fMidiPtrs->midiIn, "default", SND_SEQ_OPEN_INPUT, 0);
+	if (err < 0) {
+		delete fMidiPtrs;
+		return false;
+	}
+	snd_seq_set_client_name(fMidiPtrs->midiIn, "QMidi");
+	snd_seq_create_simple_port(fMidiPtrs->midiIn, "Input Port", SND_SEQ_PORT_CAP_WRITE,
+		SND_SEQ_PORT_TYPE_MIDI_GENERIC);
 
-    // connect the device to our previously created port
-    QStringList l = inDeviceId.split(":");
-    int client = l.at(0).toInt();
-    int port = l.at(1).toInt();
-    snd_seq_connect_from(fMidiPtrs->midiIn, 0, client, port);
+	// connect the device to our previously created port
+	QStringList l = inDeviceId.split(":");
+	int client = l.at(0).toInt();
+	int port = l.at(1).toInt();
+	snd_seq_connect_from(fMidiPtrs->midiIn, 0, client, port);
 
-    fDeviceId = inDeviceId;
-    fConnected = true;
-    return true;
+	fDeviceId = inDeviceId;
+	fConnected = true;
+	return true;
 }
 
 void QMidiIn::disconnect()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    QStringList l = fDeviceId.split(":");
-    int client = l.at(0).toInt();
-    int port = l.at(1).toInt();
+	QStringList l = fDeviceId.split(":");
+	int client = l.at(0).toInt();
+	int port = l.at(1).toInt();
 
-    snd_seq_disconnect_to(fMidiPtrs->midiIn, 0, client, port);
-    fConnected = false;
+	snd_seq_disconnect_to(fMidiPtrs->midiIn, 0, client, port);
+	fConnected = false;
 
-    snd_seq_close(fMidiPtrs->midiIn);
-    delete fMidiPtrs;
-    fMidiPtrs = nullptr;
+	snd_seq_close(fMidiPtrs->midiIn);
+	delete fMidiPtrs;
+	fMidiPtrs = nullptr;
 }
 
 void QMidiIn::start()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    fMidiPtrs->receiveThread = new MidiInReceiveThread(this, fMidiPtrs);
-    fMidiPtrs->receiveThread->start();
+	fMidiPtrs->receiveThread = new MidiInReceiveThread(this, fMidiPtrs);
+	fMidiPtrs->receiveThread->start();
 }
 
 void QMidiIn::stop()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    fMidiPtrs->receiveThread->requestInterruption();
-    fMidiPtrs->receiveThread->wait();
-    fMidiPtrs->receiveThread->deleteLater();
-    fMidiPtrs->receiveThread = nullptr;
+	fMidiPtrs->receiveThread->requestInterruption();
+	fMidiPtrs->receiveThread->wait();
+	fMidiPtrs->receiveThread->deleteLater();
+	fMidiPtrs->receiveThread = nullptr;
 }
 
 MidiInReceiveThread::MidiInReceiveThread(QMidiIn* qMidiIn, NativeMidiInInstances* fMidiPtrs, QObject* parent)
-    : QThread(parent), fMidiIn(qMidiIn), fMidiPtrs(fMidiPtrs)
+	: QThread(parent), fMidiIn(qMidiIn), fMidiPtrs(fMidiPtrs)
 {}
 
 void MidiInReceiveThread::run()
 {
-    snd_seq_event_t* ev = nullptr;
-    int data = 0;
-    int value = 0;
+	snd_seq_event_t* ev = nullptr;
+	int data = 0;
+	int value = 0;
 
-    while (!isInterruptionRequested() && fMidiIn->isConnected())
-    {
-        snd_seq_event_input(fMidiPtrs->midiIn, &ev);
+	while (!isInterruptionRequested() && fMidiIn->isConnected()) {
+		snd_seq_event_input(fMidiPtrs->midiIn, &ev);
 
-        switch (ev->type)
-        {
-        case SND_SEQ_EVENT_SYSEX:
-        {
-            QByteArray ba = QByteArray(reinterpret_cast<const char*>(ev->data.ext.ptr), ev->data.ext.len);
-            emit(fMidiIn->midiSysExEvent(ba));
-            continue;
-        }
-        case SND_SEQ_EVENT_NOTEOFF:
-            data = 0x80
-                    | (ev->data.note.channel & 0x0F)
-                    | ((ev->data.note.note & 0x7F) << 8)
-                    | ((ev->data.note.velocity & 0x7F) << 16);
-            break;
-        case SND_SEQ_EVENT_NOTEON:
-            data = 0x90
-                    | (ev->data.note.channel & 0x0F)
-                    | ((ev->data.note.note & 0x7F) << 8)
-                    | ((ev->data.note.velocity & 0x7F) << 16);
-            break;
-        case SND_SEQ_EVENT_KEYPRESS:
-            data = 0xA0
-                    | (ev->data.note.channel & 0x0F)
-                    | ((ev->data.note.note & 0x7F) << 8)
-                    | ((ev->data.note.velocity & 0x7F) << 16);
-            break;
-        case SND_SEQ_EVENT_CONTROLLER:
-            data = 0xB0
-                    | (ev->data.control.channel & 0x0F)
-                    | ((ev->data.control.param & 0x7F) << 8)
-                    | ((ev->data.control.value & 0x7F) << 16);
-            break;
-        case SND_SEQ_EVENT_PGMCHANGE:
-            data = 0xC0
-                    | (ev->data.control.channel & 0x0F)
-                    | ((ev->data.control.value & 0x7F) << 8);
-            break;
-        case SND_SEQ_EVENT_CHANPRESS:
-            data = 0xD0
-                    | (ev->data.control.channel & 0x0F)
-                    | ((ev->data.control.value & 0x7F) << 8);
-            break;
-        case SND_SEQ_EVENT_PITCHBEND:
-            value = ev->data.control.value + 8192;
-            data = 0xE0
-                    | (ev->data.note.channel & 0x0F)
-                    | ((value & 0x7F) << 8)
-                    | (((value >> 7) & 0x7F) << 16);
-            break;
-        default:
-            continue;
-        }
+		switch (ev->type) {
+		case SND_SEQ_EVENT_SYSEX:
+		{
+			QByteArray ba = QByteArray(reinterpret_cast<const char*>(ev->data.ext.ptr), ev->data.ext.len);
+			emit(fMidiIn->midiSysExEvent(ba));
+			continue;
+		}
+		case SND_SEQ_EVENT_NOTEOFF:
+			data = 0x80
+					| (ev->data.note.channel & 0x0F)
+					| ((ev->data.note.note & 0x7F) << 8)
+					| ((ev->data.note.velocity & 0x7F) << 16);
+			break;
+		case SND_SEQ_EVENT_NOTEON:
+			data = 0x90
+					| (ev->data.note.channel & 0x0F)
+					| ((ev->data.note.note & 0x7F) << 8)
+					| ((ev->data.note.velocity & 0x7F) << 16);
+			break;
+		case SND_SEQ_EVENT_KEYPRESS:
+			data = 0xA0
+					| (ev->data.note.channel & 0x0F)
+					| ((ev->data.note.note & 0x7F) << 8)
+					| ((ev->data.note.velocity & 0x7F) << 16);
+			break;
+		case SND_SEQ_EVENT_CONTROLLER:
+			data = 0xB0
+					| (ev->data.control.channel & 0x0F)
+					| ((ev->data.control.param & 0x7F) << 8)
+					| ((ev->data.control.value & 0x7F) << 16);
+			break;
+		case SND_SEQ_EVENT_PGMCHANGE:
+			data = 0xC0
+					| (ev->data.control.channel & 0x0F)
+					| ((ev->data.control.value & 0x7F) << 8);
+			break;
+		case SND_SEQ_EVENT_CHANPRESS:
+			data = 0xD0
+					| (ev->data.control.channel & 0x0F)
+					| ((ev->data.control.value & 0x7F) << 8);
+			break;
+		case SND_SEQ_EVENT_PITCHBEND:
+			value = ev->data.control.value + 8192;
+			data = 0xE0
+					| (ev->data.note.channel & 0x0F)
+					| ((value & 0x7F) << 8)
+					| (((value >> 7) & 0x7F) << 16);
+			break;
+		default:
+			continue;
+		}
 
-        emit(fMidiIn->midiEvent(static_cast<quint32>(data), ev->time.tick));
-    }
+		emit(fMidiIn->midiEvent(static_cast<quint32>(data), ev->time.tick));
+	}
 }

--- a/src/OS/QMidi_ALSA.cpp
+++ b/src/OS/QMidi_ALSA.cpp
@@ -25,7 +25,7 @@ QMap<QString, QString> QMidiOut::devices()
 	int err;
 	snd_seq_t* handle;
 
-	err = snd_seq_open(&handle, "hw", SND_SEQ_OPEN_DUPLEX, 0);
+	err = snd_seq_open(&handle, "hw", SND_SEQ_OPEN_OUTPUT, 0);
 	if (err < 0) {
 		/* Use snd_strerror(errno) to get the error here. */
 		return ret;
@@ -51,6 +51,8 @@ QMap<QString, QString> QMidiOut::devices()
 		}
 	}
 
+	snd_seq_close(handle);
+
 	return ret;
 }
 
@@ -62,7 +64,10 @@ bool QMidiOut::connect(QString outDeviceId)
 
 	int err = snd_seq_open(&fMidiPtrs->midiOutPtr, "default", SND_SEQ_OPEN_OUTPUT, 0);
 	if (err < 0)
+	{
+		delete fMidiPtrs;
 		return false;
+	}
 	snd_seq_set_client_name(fMidiPtrs->midiOutPtr, "QMidi");
 
 	snd_seq_create_simple_port(fMidiPtrs->midiOutPtr, "Output Port", SND_SEQ_PORT_CAP_READ,
@@ -90,6 +95,7 @@ void QMidiOut::disconnect()
 	snd_seq_disconnect_from(fMidiPtrs->midiOutPtr, 0, client, port);
 	fConnected = false;
 
+	snd_seq_close(fMidiPtrs->midiOutPtr);
 	delete fMidiPtrs;
 	fMidiPtrs = NULL;
 }
@@ -118,4 +124,30 @@ void QMidiOut::sendMsg(qint32 msg)
 
 	snd_seq_event_output(fMidiPtrs->midiOutPtr, &ev);
 	snd_seq_drain_output(fMidiPtrs->midiOutPtr);
+
+	snd_midi_event_free(mev);
+}
+
+void QMidiOut::sendSysEx(const QByteArray &data)
+{
+    if (!fConnected)
+    {
+        return;
+    }
+
+    snd_seq_event_t ev;
+    snd_midi_event_t* mev;
+
+    snd_seq_ev_set_source(&ev, 0);
+    snd_seq_ev_set_subs(&ev);
+    snd_seq_ev_set_direct(&ev);
+
+    snd_midi_event_new(data.size(), &mev);
+    snd_midi_event_resize_buffer(mev, data.size());
+    snd_midi_event_encode(mev, (unsigned char*) data.data(), data.size(), &ev);
+
+    snd_seq_event_output(fMidiPtrs->midiOutPtr, &ev);
+    snd_seq_drain_output(fMidiPtrs->midiOutPtr);
+
+    snd_midi_event_free(mev);
 }

--- a/src/OS/QMidi_ALSA.cpp
+++ b/src/OS/QMidi_ALSA.cpp
@@ -172,7 +172,7 @@ struct NativeMidiInInstances {
 	snd_seq_t* midiIn;
 
 	//! \brief receiveThread is a reference to the MIDI input receive thread.
-	MidiInReceiveThread* receiveThread;
+	QMidiInternal::MidiInReceiveThread* receiveThread;
 };
 
 QMap<QString, QString> QMidiIn::devices()
@@ -228,7 +228,7 @@ void QMidiIn::start()
 	if (!fConnected)
 		return;
 
-	fMidiPtrs->receiveThread = new MidiInReceiveThread(this, fMidiPtrs);
+	fMidiPtrs->receiveThread = new QMidiInternal::MidiInReceiveThread(this, fMidiPtrs);
 	fMidiPtrs->receiveThread->start();
 }
 
@@ -243,11 +243,11 @@ void QMidiIn::stop()
 	fMidiPtrs->receiveThread = nullptr;
 }
 
-MidiInReceiveThread::MidiInReceiveThread(QMidiIn* qMidiIn, NativeMidiInInstances* fMidiPtrs, QObject* parent)
+QMidiInternal::MidiInReceiveThread::MidiInReceiveThread(QMidiIn* qMidiIn, NativeMidiInInstances* fMidiPtrs, QObject* parent)
 	: QThread(parent), fMidiIn(qMidiIn), fMidiPtrs(fMidiPtrs)
 {}
 
-void MidiInReceiveThread::run()
+void QMidiInternal::MidiInReceiveThread::run()
 {
 	snd_seq_event_t* ev = nullptr;
 	int data = 0;

--- a/src/OS/QMidi_ALSA.h
+++ b/src/OS/QMidi_ALSA.h
@@ -9,22 +9,20 @@
 class QMidiIn;
 struct NativeMidiInInstances;
 
-//!
 //! \brief The MidiInReceiveThread class runs the ALSA MIDI input thread.  This
 //! is required since the function that reads input from a \c snd_seq_t handle
 //! blocks.
-//!
 class MidiInReceiveThread : public QThread
 {
-    Q_OBJECT
+	Q_OBJECT
 
 public:
-    MidiInReceiveThread(QMidiIn* qMidiIn, NativeMidiInInstances* fMidiPtrs, QObject* parent = nullptr);
+	MidiInReceiveThread(QMidiIn* qMidiIn, NativeMidiInInstances* fMidiPtrs, QObject* parent = nullptr);
 
 private:
-    void run() override;
+	void run() override;
 
 private:
-    QMidiIn* fMidiIn;
-    NativeMidiInInstances* fMidiPtrs;
+	QMidiIn* fMidiIn;
+	NativeMidiInInstances* fMidiPtrs;
 };

--- a/src/OS/QMidi_ALSA.h
+++ b/src/OS/QMidi_ALSA.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Georg Gadinger <nilsding@nilsding.org>
+ * Distributed under the terms of the MIT license.
+ */
+#pragma once
+
+#include <QThread>
+
+class QMidiIn;
+struct NativeMidiInInstances;
+
+//!
+//! \brief The MidiInReceiveThread class runs the ALSA MIDI input thread.  This
+//! is required since the function that reads input from a \c snd_seq_t handle
+//! blocks.
+//!
+class MidiInReceiveThread : public QThread
+{
+    Q_OBJECT
+
+public:
+    MidiInReceiveThread(QMidiIn* qMidiIn, NativeMidiInInstances* fMidiPtrs, QObject* parent = nullptr);
+
+private:
+    void run() override;
+
+private:
+    QMidiIn* fMidiIn;
+    NativeMidiInInstances* fMidiPtrs;
+};

--- a/src/OS/QMidi_ALSA.h
+++ b/src/OS/QMidi_ALSA.h
@@ -9,6 +9,8 @@
 class QMidiIn;
 struct NativeMidiInInstances;
 
+namespace QMidiInternal
+{
 //! \brief The MidiInReceiveThread class runs the ALSA MIDI input thread.  This
 //! is required since the function that reads input from a \c snd_seq_t handle
 //! blocks.
@@ -25,4 +27,5 @@ private:
 private:
 	QMidiIn* fMidiIn;
 	NativeMidiInInstances* fMidiPtrs;
+};
 };

--- a/src/OS/QMidi_Haiku.cpp
+++ b/src/OS/QMidi_Haiku.cpp
@@ -109,7 +109,7 @@ void QMidiOut::sendSysEx(const QByteArray &data)
 
 struct NativeMidiInInstances {
 	BMidiProducer* midiInProducer;
-	MidiInConsumer* midiInConsumer;
+	QMidiInternal::MidiInConsumer* midiInConsumer;
 };
 
 QMap<QString, QString> QMidiIn::devices()
@@ -142,7 +142,7 @@ bool QMidiIn::connect(QString inDeviceId)
 	if (fMidiPtrs->midiInProducer == NULL) {
 		return false;
 	}
-	fMidiPtrs->midiInConsumer = new MidiInConsumer(this, "QMidi");
+	fMidiPtrs->midiInConsumer = new QMidiInternal::MidiInConsumer(this, "QMidi");
 	if (!fMidiPtrs->midiInConsumer->IsValid()) {
 		fMidiPtrs->midiInConsumer->Release();
 		return false;
@@ -190,12 +190,12 @@ void QMidiIn::stop()
 	fMidiPtrs->midiInProducer->Disconnect(fMidiPtrs->midiInConsumer);
 }
 
-MidiInConsumer::MidiInConsumer(QMidiIn* midiIn, const char* name)
+QMidiInternal::MidiInConsumer::MidiInConsumer(QMidiIn* midiIn, const char* name)
 	: BMidiLocalConsumer(name), fMidiIn(midiIn)
 {
 }
 
-void MidiInConsumer::ChannelPressure(uchar channel, uchar pressure, bigtime_t time)
+void QMidiInternal::MidiInConsumer::ChannelPressure(uchar channel, uchar pressure, bigtime_t time)
 {
 	int data = 0xD0
 			| (channel & 0x0F)
@@ -203,7 +203,7 @@ void MidiInConsumer::ChannelPressure(uchar channel, uchar pressure, bigtime_t ti
 	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
-void MidiInConsumer::ControlChange(uchar channel, uchar controlNumber, uchar controlValue, bigtime_t time)
+void QMidiInternal::MidiInConsumer::ControlChange(uchar channel, uchar controlNumber, uchar controlValue, bigtime_t time)
 {
 	int data = 0xB0
 			| (channel & 0x0F)
@@ -212,7 +212,7 @@ void MidiInConsumer::ControlChange(uchar channel, uchar controlNumber, uchar con
 	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
-void MidiInConsumer::KeyPressure(uchar channel, uchar note, uchar pressure, bigtime_t time)
+void QMidiInternal::MidiInConsumer::KeyPressure(uchar channel, uchar note, uchar pressure, bigtime_t time)
 {
 	int data = 0xA0
 			| (channel & 0x0F)
@@ -221,7 +221,7 @@ void MidiInConsumer::KeyPressure(uchar channel, uchar note, uchar pressure, bigt
 	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
-void MidiInConsumer::NoteOff(uchar channel, uchar note, uchar velocity, bigtime_t time)
+void QMidiInternal::MidiInConsumer::NoteOff(uchar channel, uchar note, uchar velocity, bigtime_t time)
 {
 	int data = 0x80
 			| (channel & 0x0F)
@@ -230,7 +230,7 @@ void MidiInConsumer::NoteOff(uchar channel, uchar note, uchar velocity, bigtime_
 	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
-void MidiInConsumer::NoteOn(uchar channel, uchar note, uchar velocity, bigtime_t time)
+void QMidiInternal::MidiInConsumer::NoteOn(uchar channel, uchar note, uchar velocity, bigtime_t time)
 {
 	int data = 0x90
 			| (channel & 0x0F)
@@ -239,7 +239,7 @@ void MidiInConsumer::NoteOn(uchar channel, uchar note, uchar velocity, bigtime_t
 	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
-void MidiInConsumer::PitchBend(uchar channel, uchar lsb, uchar msb, bigtime_t time)
+void QMidiInternal::MidiInConsumer::PitchBend(uchar channel, uchar lsb, uchar msb, bigtime_t time)
 {
 	int data = 0xE0
 			| (channel & 0x0F)
@@ -248,7 +248,7 @@ void MidiInConsumer::PitchBend(uchar channel, uchar lsb, uchar msb, bigtime_t ti
 	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
-void MidiInConsumer::ProgramChange(uchar channel, uchar programNumber, bigtime_t time)
+void QMidiInternal::MidiInConsumer::ProgramChange(uchar channel, uchar programNumber, bigtime_t time)
 {
 	int data = 0xC0
 			| (channel & 0x0F)
@@ -256,7 +256,7 @@ void MidiInConsumer::ProgramChange(uchar channel, uchar programNumber, bigtime_t
 	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
-void MidiInConsumer::SystemExclusive(void* data, size_t length, bigtime_t time)
+void QMidiInternal::MidiInConsumer::SystemExclusive(void* data, size_t length, bigtime_t time)
 {
 	QByteArray ba = QByteArray(reinterpret_cast<const char*>(data), length);
 	ba.prepend('\xF0');

--- a/src/OS/QMidi_Haiku.cpp
+++ b/src/OS/QMidi_Haiku.cpp
@@ -79,10 +79,25 @@ void QMidiOut::sendMsg(qint32 msg)
 	if (!fConnected)
 		return;
 
+	size_t bufferLength = 3;
 	char buf[3];
 	buf[0] = msg & 0xFF;
 	buf[1] = (msg >> 8) & 0xFF;
 	buf[2] = (msg >> 16) & 0xFF;
 
-	fMidiPtrs->midiOutLocProd->SprayData((void*)&buf, 3, true);
+	if (buf[0] == '\xC0' || buf[0] == '\xD0')
+	{
+		// workaround for Haiku bug #15562
+		bufferLength = 2;
+	}
+
+	fMidiPtrs->midiOutLocProd->SprayData((void*)&buf, bufferLength, true);
+}
+
+void QMidiOut::sendSysEx(const QByteArray &data)
+{
+    if (!fConnected)
+        return;
+
+    fMidiPtrs->midiOutLocProd->SprayData((char*)data.data(), data.length(), false);
 }

--- a/src/OS/QMidi_Haiku.cpp
+++ b/src/OS/QMidi_Haiku.cpp
@@ -3,12 +3,14 @@
  * All rights reserved. Distributed under the terms of the MIT license.
  */
 #include "QMidiOut.h"
+#include "QMidiIn.h"
+#include "OS/QMidi_Haiku.h"
 
 #include <MidiRoster.h>
 #include <MidiConsumer.h>
 #include <MidiProducer.h>
 
-/* -----------------------------[ QMidiOut ]------------------------------ */
+// # pragma mark - QMidiOut
 
 struct NativeMidiOutInstances {
 	BMidiConsumer* midiOutConsumer;
@@ -87,8 +89,7 @@ void QMidiOut::sendMsg(qint32 msg)
 	buf[1] = (msg >> 8) & 0xFF;
 	buf[2] = (msg >> 16) & 0xFF;
 
-	if (buf[0] == '\xC0' || buf[0] == '\xD0')
-	{
+	if (buf[0] == '\xC0' || buf[0] == '\xD0') {
 		// workaround for Haiku bug #15562
 		bufferLength = 2;
 	}
@@ -98,178 +99,167 @@ void QMidiOut::sendMsg(qint32 msg)
 
 void QMidiOut::sendSysEx(const QByteArray &data)
 {
-    if (!fConnected)
-        return;
+	if (!fConnected)
+		return;
 
-    fMidiPtrs->midiOutLocProd->SprayData((char*)data.data(), data.length(), false);
+	fMidiPtrs->midiOutLocProd->SprayData((char*)data.data(), data.length(), false);
 }
 
-/* ------------------------------[ QMidiIn ]------------------------------ */
-
-#include "QMidiIn.h"
-#include "OS/QMidi_Haiku.h"
+// # pragma mark - QMidiIn
 
 struct NativeMidiInInstances {
-    BMidiProducer* midiInProducer;
-    MidiInConsumer* midiInConsumer;
+	BMidiProducer* midiInProducer;
+	MidiInConsumer* midiInConsumer;
 };
 
 QMap<QString, QString> QMidiIn::devices()
 {
-    QMap<QString, QString> ret;
+	QMap<QString, QString> ret;
 
-    bool OK = true;
-    int32 id = 0;
-    while (OK) {
-        BMidiProducer* c = BMidiRoster::NextProducer(&id);
-        if (c != NULL) {
-            ret.insert(QString::number(id), QString::fromUtf8(c->Name()));
-            c->Release();
-        } else {
-            OK = false;
-        }
-    }
+	bool OK = true;
+	int32 id = 0;
+	while (OK) {
+		BMidiProducer* c = BMidiRoster::NextProducer(&id);
+		if (c != NULL) {
+			ret.insert(QString::number(id), QString::fromUtf8(c->Name()));
+			c->Release();
+		} else {
+			OK = false;
+		}
+	}
 
-    return ret;
+	return ret;
 }
 
 bool QMidiIn::connect(QString inDeviceId)
 {
-    if (fConnected)
-    {
-        disconnect();
-    }
+	if (fConnected)
+		disconnect();
 
-    fMidiPtrs = new NativeMidiInInstances;
+	fMidiPtrs = new NativeMidiInInstances;
 
-    fMidiPtrs->midiInProducer = BMidiRoster::FindProducer(inDeviceId.toInt());
-    if (fMidiPtrs->midiInProducer == NULL) {
-        return false;
-    }
-    fMidiPtrs->midiInConsumer = new MidiInConsumer(this, "QMidi");
-    if (!fMidiPtrs->midiInConsumer->IsValid()) {
-        fMidiPtrs->midiInConsumer->Release();
-        return false;
-    }
-    fMidiPtrs->midiInConsumer->Register();
+	fMidiPtrs->midiInProducer = BMidiRoster::FindProducer(inDeviceId.toInt());
+	if (fMidiPtrs->midiInProducer == NULL) {
+		return false;
+	}
+	fMidiPtrs->midiInConsumer = new MidiInConsumer(this, "QMidi");
+	if (!fMidiPtrs->midiInConsumer->IsValid()) {
+		fMidiPtrs->midiInConsumer->Release();
+		return false;
+	}
+	fMidiPtrs->midiInConsumer->Register();
 
-    fDeviceId = inDeviceId;
-    fConnected = true;
+	fDeviceId = inDeviceId;
+	fConnected = true;
 
-    return true;
+	return true;
 }
 
 void QMidiIn::disconnect()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    stop();
+	stop();
 
-    fMidiPtrs->midiInConsumer->Release();
-    fMidiPtrs->midiInConsumer->Unregister();
-    fMidiPtrs->midiInProducer->Release();
+	fMidiPtrs->midiInConsumer->Release();
+	fMidiPtrs->midiInConsumer->Unregister();
+	fMidiPtrs->midiInProducer->Release();
 
-    fConnected = false;
-    delete fMidiPtrs;
-    fMidiPtrs = NULL;
+	fConnected = false;
+	delete fMidiPtrs;
+	fMidiPtrs = NULL;
 }
 
 void QMidiIn::start()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    if (fMidiPtrs->midiInProducer->Connect(fMidiPtrs->midiInConsumer) != B_OK) {
-        qWarning("QMidiIn::start: could not connect producer with our consumer");
-        return;
-    }
+	if (fMidiPtrs->midiInProducer->Connect(fMidiPtrs->midiInConsumer) != B_OK) {
+		qWarning("QMidiIn::start: could not connect producer with our consumer");
+		return;
+	}
 }
 
 void QMidiIn::stop()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    fMidiPtrs->midiInProducer->Disconnect(fMidiPtrs->midiInConsumer);
+	fMidiPtrs->midiInProducer->Disconnect(fMidiPtrs->midiInConsumer);
 }
 
 MidiInConsumer::MidiInConsumer(QMidiIn* midiIn, const char* name)
-    : BMidiLocalConsumer(name), fMidiIn(midiIn)
+	: BMidiLocalConsumer(name), fMidiIn(midiIn)
 {
 }
 
 void MidiInConsumer::ChannelPressure(uchar channel, uchar pressure, bigtime_t time)
 {
-    int data = 0xD0
-            | (channel & 0x0F)
-            | (pressure << 8);
-    emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
+	int data = 0xD0
+			| (channel & 0x0F)
+			| (pressure << 8);
+	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
 void MidiInConsumer::ControlChange(uchar channel, uchar controlNumber, uchar controlValue, bigtime_t time)
 {
-    int data = 0xB0
-            | (channel & 0x0F)
-            | (controlNumber << 8)
-            | (controlValue << 16);
-    emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
+	int data = 0xB0
+			| (channel & 0x0F)
+			| (controlNumber << 8)
+			| (controlValue << 16);
+	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
 void MidiInConsumer::KeyPressure(uchar channel, uchar note, uchar pressure, bigtime_t time)
 {
-    int data = 0xA0
-            | (channel & 0x0F)
-            | (note << 8)
-            | (pressure << 16);
-    emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
+	int data = 0xA0
+			| (channel & 0x0F)
+			| (note << 8)
+			| (pressure << 16);
+	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
 void MidiInConsumer::NoteOff(uchar channel, uchar note, uchar velocity, bigtime_t time)
 {
-    int data = 0x80
-            | (channel & 0x0F)
-            | (note << 8)
-            | (velocity << 16);
-    emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
+	int data = 0x80
+			| (channel & 0x0F)
+			| (note << 8)
+			| (velocity << 16);
+	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
 void MidiInConsumer::NoteOn(uchar channel, uchar note, uchar velocity, bigtime_t time)
 {
-    int data = 0x90
-            | (channel & 0x0F)
-            | (note << 8)
-            | (velocity << 16);
-    emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
+	int data = 0x90
+			| (channel & 0x0F)
+			| (note << 8)
+			| (velocity << 16);
+	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
 void MidiInConsumer::PitchBend(uchar channel, uchar lsb, uchar msb, bigtime_t time)
 {
-    int data = 0xE0
-            | (channel & 0x0F)
-            | (lsb << 8)
-            | (msb << 16);
-    emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
+	int data = 0xE0
+			| (channel & 0x0F)
+			| (lsb << 8)
+			| (msb << 16);
+	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
 void MidiInConsumer::ProgramChange(uchar channel, uchar programNumber, bigtime_t time)
 {
-    int data = 0xC0
-            | (channel & 0x0F)
-            | (programNumber << 8);
-    emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
+	int data = 0xC0
+			| (channel & 0x0F)
+			| (programNumber << 8);
+	emit(fMidiIn->midiEvent(static_cast<quint32>(data), time));
 }
 
 void MidiInConsumer::SystemExclusive(void* data, size_t length, bigtime_t time)
 {
-   QByteArray ba = QByteArray(reinterpret_cast<const char*>(data), length);
-   ba.prepend('\xF0');
-   ba.append('\xF7');
-   emit(fMidiIn->midiSysExEvent(ba));
+	QByteArray ba = QByteArray(reinterpret_cast<const char*>(data), length);
+	ba.prepend('\xF0');
+	ba.append('\xF7');
+	emit(fMidiIn->midiSysExEvent(ba));
 }

--- a/src/OS/QMidi_Haiku.h
+++ b/src/OS/QMidi_Haiku.h
@@ -8,6 +8,8 @@
 
 class QMidiIn;
 
+namespace QMidiInternal
+{
 class MidiInConsumer : public BMidiLocalConsumer
 {
 public:
@@ -25,3 +27,4 @@ public:
 private:
 	QMidiIn* fMidiIn;
 };
+}

--- a/src/OS/QMidi_Haiku.h
+++ b/src/OS/QMidi_Haiku.h
@@ -11,17 +11,17 @@ class QMidiIn;
 class MidiInConsumer : public BMidiLocalConsumer
 {
 public:
-    MidiInConsumer(QMidiIn* midiIn, const char *name = NULL);
+	MidiInConsumer(QMidiIn* midiIn, const char *name = NULL);
 
-    void ChannelPressure(uchar channel, uchar pressure, bigtime_t time) override;
-    void ControlChange(uchar channel, uchar controlNumber, uchar controlValue, bigtime_t time) override;
-    void KeyPressure(uchar channel, uchar note, uchar pressure, bigtime_t time) override;
-    void NoteOff(uchar channel, uchar note, uchar velocity, bigtime_t time) override;
-    void NoteOn(uchar channel, uchar note, uchar velocity, bigtime_t time) override;
-    void PitchBend(uchar channel, uchar lsb, uchar msb, bigtime_t time) override;
-    void ProgramChange(uchar channel, uchar programNumber, bigtime_t time) override;
-    void SystemExclusive(void* data, size_t length, bigtime_t time) override;
+	void ChannelPressure(uchar channel, uchar pressure, bigtime_t time) override;
+	void ControlChange(uchar channel, uchar controlNumber, uchar controlValue, bigtime_t time) override;
+	void KeyPressure(uchar channel, uchar note, uchar pressure, bigtime_t time) override;
+	void NoteOff(uchar channel, uchar note, uchar velocity, bigtime_t time) override;
+	void NoteOn(uchar channel, uchar note, uchar velocity, bigtime_t time) override;
+	void PitchBend(uchar channel, uchar lsb, uchar msb, bigtime_t time) override;
+	void ProgramChange(uchar channel, uchar programNumber, bigtime_t time) override;
+	void SystemExclusive(void* data, size_t length, bigtime_t time) override;
 
 private:
-    QMidiIn* fMidiIn;
+	QMidiIn* fMidiIn;
 };

--- a/src/OS/QMidi_Haiku.h
+++ b/src/OS/QMidi_Haiku.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Georg Gadinger <nilsding@nilsding.org>
+ * Distributed under the terms of the MIT license.
+ */
+#pragma once
+
+#include <MidiConsumer.h>
+
+class QMidiIn;
+
+class MidiInConsumer : public BMidiLocalConsumer
+{
+public:
+    MidiInConsumer(QMidiIn* midiIn, const char *name = NULL);
+
+    void ChannelPressure(uchar channel, uchar pressure, bigtime_t time) override;
+    void ControlChange(uchar channel, uchar controlNumber, uchar controlValue, bigtime_t time) override;
+    void KeyPressure(uchar channel, uchar note, uchar pressure, bigtime_t time) override;
+    void NoteOff(uchar channel, uchar note, uchar velocity, bigtime_t time) override;
+    void NoteOn(uchar channel, uchar note, uchar velocity, bigtime_t time) override;
+    void PitchBend(uchar channel, uchar lsb, uchar msb, bigtime_t time) override;
+    void ProgramChange(uchar channel, uchar programNumber, bigtime_t time) override;
+    void SystemExclusive(void* data, size_t length, bigtime_t time) override;
+
+private:
+    QMidiIn* fMidiIn;
+};

--- a/src/OS/QMidi_Win32.cpp
+++ b/src/OS/QMidi_Win32.cpp
@@ -3,6 +3,7 @@
  * All rights reserved. Distributed under the terms of the MIT license.
  */
 #include "QMidiOut.h"
+#include "QMidiIn.h"
 #include "QMidiFile.h"
 
 #include <QStringList>
@@ -11,7 +12,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 
-/* -----------------------------[ QMidiOut ]------------------------------ */
+// # pragma mark - QMidiOut
 
 struct NativeMidiOutInstances {
 	HMIDIOUT midiOut;
@@ -71,144 +72,125 @@ void QMidiOut::sendMsg(qint32 msg)
 
 void QMidiOut::sendSysEx(const QByteArray &data)
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    MIDIHDR header;
-    memset(&header, 0, sizeof(MIDIHDR));
+	MIDIHDR header;
+	memset(&header, 0, sizeof(MIDIHDR));
 
-    header.lpData = (LPSTR) data.data();
-    header.dwBufferLength = data.length();
+	header.lpData = (LPSTR) data.data();
+	header.dwBufferLength = data.length();
 
-    // TODO: check for retval of midiOutPrepareHeader
-    midiOutPrepareHeader(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR));
+	// TODO: check for retval of midiOutPrepareHeader
+	midiOutPrepareHeader(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR));
 
-    midiOutLongMsg(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR));
+	midiOutLongMsg(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR));
 
-    while (midiOutUnprepareHeader(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR)) == MIDIERR_STILLPLAYING);
+	while (midiOutUnprepareHeader(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR)) == MIDIERR_STILLPLAYING);
 }
 
-/* ------------------------------[ QMidiIn ]------------------------------ */
-
-#include "QMidiIn.h"
+// # pragma mark - QMidiIn
 
 struct NativeMidiInInstances {
-    //!
-    //! \brief midiIn is a reference to the MIDI input device
-    //!
-    HMIDIIN midiIn;
-    //!
-    //! \brief header is a prepared MIDI header, used for receiving
-    //! MIM_LONGDATA (System Exclusive) messages.
-    //!
-    MIDIHDR header;
+	//! \brief midiIn is a reference to the MIDI input device
+	HMIDIIN midiIn;
+	//! \brief header is a prepared MIDI header, used for receiving
+	//! MIM_LONGDATA (System Exclusive) messages.
+	MIDIHDR header;
 };
 
 QMap<QString, QString> QMidiIn::devices()
 {
-    QMap<QString, QString> ret;
+	QMap<QString, QString> ret;
 
-    unsigned int numDevs = midiInGetNumDevs();
-    if (numDevs == 0)
-    {
-        return ret;
-    }
+	unsigned int numDevs = midiInGetNumDevs();
+	if (numDevs == 0)
+		return ret;
 
-    for (unsigned int i = 0; i < numDevs; i++)
-    {
-        MIDIINCAPSW devCaps;
-        midiInGetDevCapsW(i, &devCaps, sizeof(MIDIINCAPSW));
-        ret.insert(QString::number(i), QString::fromWCharArray(devCaps.szPname));
-    }
+	for (unsigned int i = 0; i < numDevs; i++) {
+		MIDIINCAPSW devCaps;
+		midiInGetDevCapsW(i, &devCaps, sizeof(MIDIINCAPSW));
+		ret.insert(QString::number(i), QString::fromWCharArray(devCaps.szPname));
+	}
 
-    return ret;
+	return ret;
 }
 
 static void CALLBACK QMidiInProc(HMIDIIN hMidiIn, UINT wMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2)
 {
-    QMidiIn* self = reinterpret_cast<QMidiIn*>(dwInstance);
-    switch (wMsg)
-    {
-    case MIM_OPEN:
-    case MIM_CLOSE:
-        break;
-    case MIM_DATA:
-        emit(self->midiEvent(static_cast<quint32>(dwParam1), static_cast<quint32>(dwParam2)));
-        break;
-    case MIM_LONGDATA:
-    {
-        auto midiHeader = reinterpret_cast<MIDIHDR*>(dwParam1);
-        auto rawData = QByteArray(midiHeader->lpData, static_cast<int>(midiHeader->dwBytesRecorded));
-        emit(self->midiSysExEvent(rawData));
+	QMidiIn* self = reinterpret_cast<QMidiIn*>(dwInstance);
+	switch (wMsg)
+	{
+	case MIM_OPEN:
+	case MIM_CLOSE:
+		break;
+	case MIM_DATA:
+		emit(self->midiEvent(static_cast<quint32>(dwParam1), static_cast<quint32>(dwParam2)));
+		break;
+	case MIM_LONGDATA:
+	{
+		auto midiHeader = reinterpret_cast<MIDIHDR*>(dwParam1);
+		auto rawData = QByteArray(midiHeader->lpData, static_cast<int>(midiHeader->dwBytesRecorded));
+		emit(self->midiSysExEvent(rawData));
 
-        // Prepare the midi header to be reused -- what's the worst that could happen?
-        midiInUnprepareHeader(hMidiIn, midiHeader, sizeof(MIDIHDR));
-        midiInPrepareHeader(hMidiIn, midiHeader, sizeof(MIDIHDR));
-        midiInAddBuffer(hMidiIn, midiHeader, sizeof(MIDIHDR));
-        break;
-    }
-    default:
-        qWarning("QMidi_Win32: no handler for message %d", wMsg);
-    }
+		// Prepare the midi header to be reused -- what's the worst that could happen?
+		midiInUnprepareHeader(hMidiIn, midiHeader, sizeof(MIDIHDR));
+		midiInPrepareHeader(hMidiIn, midiHeader, sizeof(MIDIHDR));
+		midiInAddBuffer(hMidiIn, midiHeader, sizeof(MIDIHDR));
+		break;
+	}
+	default:
+		qWarning("QMidi_Win32: no handler for message %d", wMsg);
+	}
 }
 
 bool QMidiIn::connect(QString inDeviceId)
 {
-    if (fConnected)
-    {
-        disconnect();
-    }
-    fMidiPtrs = new NativeMidiInInstances;
+	if (fConnected)
+		disconnect();
+	fMidiPtrs = new NativeMidiInInstances;
 
-    fDeviceId = inDeviceId;
-    midiInOpen(&fMidiPtrs->midiIn,
-               inDeviceId.toInt(),
-               reinterpret_cast<DWORD_PTR>(&QMidiInProc),
-               reinterpret_cast<DWORD_PTR>(this),
-               CALLBACK_FUNCTION | MIDI_IO_STATUS);
+	fDeviceId = inDeviceId;
+	midiInOpen(&fMidiPtrs->midiIn,
+		inDeviceId.toInt(),
+		reinterpret_cast<DWORD_PTR>(&QMidiInProc),
+		reinterpret_cast<DWORD_PTR>(this),
+		CALLBACK_FUNCTION | MIDI_IO_STATUS);
 
-    memset(&fMidiPtrs->header, 0, sizeof(MIDIHDR));
-    fMidiPtrs->header.lpData = new char[512];  // 512 bytes ought to be enough for everyone
-    fMidiPtrs->header.dwBufferLength = 512;
-    midiInPrepareHeader(fMidiPtrs->midiIn, &fMidiPtrs->header, sizeof(MIDIHDR));
-    midiInAddBuffer(fMidiPtrs->midiIn, &fMidiPtrs->header, sizeof(MIDIHDR));
+	memset(&fMidiPtrs->header, 0, sizeof(MIDIHDR));
+	fMidiPtrs->header.lpData = new char[512];  // 512 bytes ought to be enough for everyone
+	fMidiPtrs->header.dwBufferLength = 512;
+	midiInPrepareHeader(fMidiPtrs->midiIn, &fMidiPtrs->header, sizeof(MIDIHDR));
+	midiInAddBuffer(fMidiPtrs->midiIn, &fMidiPtrs->header, sizeof(MIDIHDR));
 
-    fConnected = true;
-    return true;
+	fConnected = true;
+	return true;
 }
 
 void QMidiIn::disconnect()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    delete fMidiPtrs->header.lpData;
-    midiInClose(fMidiPtrs->midiIn);
-    fConnected = false;
-    delete fMidiPtrs;
-    fMidiPtrs = nullptr;
+	delete fMidiPtrs->header.lpData;
+	midiInClose(fMidiPtrs->midiIn);
+	fConnected = false;
+	delete fMidiPtrs;
+	fMidiPtrs = nullptr;
 }
 
 void QMidiIn::start()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    midiInStart(fMidiPtrs->midiIn);
+	midiInStart(fMidiPtrs->midiIn);
 }
 
 void QMidiIn::stop()
 {
-    if (!fConnected)
-    {
-        return;
-    }
+	if (!fConnected)
+		return;
 
-    midiInStop(fMidiPtrs->midiIn);
+	midiInStop(fMidiPtrs->midiIn);
 }

--- a/src/OS/QMidi_Win32.cpp
+++ b/src/OS/QMidi_Win32.cpp
@@ -69,6 +69,27 @@ void QMidiOut::sendMsg(qint32 msg)
 	midiOutShortMsg(fMidiPtrs->midiOut, (DWORD)msg);
 }
 
+void QMidiOut::sendSysEx(const QByteArray &data)
+{
+    if (!fConnected)
+    {
+        return;
+    }
+
+    MIDIHDR header;
+    memset(&header, 0, sizeof(MIDIHDR));
+
+    header.lpData = (LPSTR) data.data();
+    header.dwBufferLength = data.length();
+
+    // TODO: check for retval of midiOutPrepareHeader
+    midiOutPrepareHeader(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR));
+
+    midiOutLongMsg(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR));
+
+    while (midiOutUnprepareHeader(fMidiPtrs->midiOut, &header, sizeof(MIDIHDR)) == MIDIERR_STILLPLAYING);
+}
+
 /* ------------------------------[ QMidiIn ]------------------------------ */
 
 #include "QMidiIn.h"

--- a/src/QMidi.pri
+++ b/src/QMidi.pri
@@ -24,4 +24,5 @@ linux* {
 haiku* {
 	LIBS += -lmidi2
 	SOURCES += $$PWD/OS/QMidi_Haiku.cpp
+	HEADERS += $$PWD/OS/QMidi_Haiku.h
 }

--- a/src/QMidi.pri
+++ b/src/QMidi.pri
@@ -3,10 +3,12 @@ CONFIG += c++11
 
 INCLUDEPATH += $$PWD
 SOURCES += $$PWD/QMidiOut.cpp \
-	$$PWD/QMidiFile.cpp
+	$$PWD/QMidiFile.cpp \
+	$$PWD/QMidiIn.cpp
 
 HEADERS += $$PWD/QMidiOut.h \
-	$$PWD/QMidiFile.h
+	$$PWD/QMidiFile.h \
+	$$PWD/QMidiIn.h
 
 win32 {
 	LIBS += -lwinmm

--- a/src/QMidi.pri
+++ b/src/QMidi.pri
@@ -18,6 +18,7 @@ win32 {
 linux* {
 	LIBS += -lasound
 	SOURCES += $$PWD/OS/QMidi_ALSA.cpp
+	HEADERS += $$PWD/OS/QMidi_ALSA.h
 }
 
 haiku* {

--- a/src/QMidiFile.h
+++ b/src/QMidiFile.h
@@ -37,7 +37,7 @@ public:
 	QMidiEvent();
 	~QMidiEvent();
 
-	inline EventType type() { return fType; }
+	inline EventType type() const { return fType; }
 	inline void setType(EventType newType) { fType = newType; }
 
 	inline qint32 tick() { return fTick; }
@@ -74,7 +74,7 @@ public:
 	inline int denominator() { return fDenominator; }
 	inline void setDenominator(int denominator) { fDenominator = denominator; }
 
-	inline QByteArray data() { return fData; }
+	inline QByteArray data() const { return fData; }
 	inline void setData(QByteArray data) { fData = data; }
 
 	quint32 message() const;

--- a/src/QMidiIn.cpp
+++ b/src/QMidiIn.cpp
@@ -5,14 +5,14 @@
 #include "QMidiIn.h"
 
 QMidiIn::QMidiIn(QObject *parent)
-    : QObject(parent),
-      fMidiPtrs(nullptr),
-      fConnected(false)
+	: QObject(parent),
+	fMidiPtrs(nullptr),
+	fConnected(false)
 {
 }
 
 QMidiIn::~QMidiIn()
 {
-    if (fConnected)
-        disconnect();
+	if (fConnected)
+		disconnect();
 }

--- a/src/QMidiIn.cpp
+++ b/src/QMidiIn.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Georg Gadinger <nilsding@nilsding.org>
+ * Distributed under the terms of the MIT license.
+ */
+#include "QMidiIn.h"
+
+QMidiIn::QMidiIn(QObject *parent)
+    : QObject(parent),
+      fMidiPtrs(nullptr),
+      fConnected(false)
+{
+}
+
+QMidiIn::~QMidiIn()
+{
+    if (fConnected)
+        disconnect();
+}

--- a/src/QMidiIn.h
+++ b/src/QMidiIn.h
@@ -12,88 +12,69 @@ struct NativeMidiInInstances;
 
 class QMidiIn : public QObject
 {
-    Q_OBJECT
+	Q_OBJECT
 public:
-    //!
-    //! \brief Devices returns a list of MIDI input devices.
-    //!
-    //! The items in the returned QMap specify the internal device ID as the
-    //! \c key which needs to be used with QMidiIn::connect, whereas the
-    //! \c value contains the device name that can be used e.g. in a QComboBox.
-    //!
-    //! \return QMap<device ID, human-readable device name>
-    //!
-    static QMap<QString /* key */, QString /* name */> devices();
+	//! \brief Devices returns a list of MIDI input devices.
+	//!
+	//! The items in the returned QMap specify the internal device ID as the
+	//! \c key which needs to be used with QMidiIn::connect, whereas the
+	//! \c value contains the device name that can be used e.g. in a QComboBox.
+	//! \return QMap<device ID, human-readable device name>
+	static QMap<QString /* key */, QString /* name */> devices();
 
-    explicit QMidiIn(QObject *parent = nullptr);
-    ~QMidiIn();
+	explicit QMidiIn(QObject *parent = nullptr);
+	~QMidiIn();
 
-    //!
-    //! \brief connect Connect to the MIDI input device specified by
-    //! <tt>inDeviceId</tt>.
-    //! \param inDeviceId The device ID, as returned by QMidiIn::devices.
-    //! \return \c true if the connection was successful, \c false otherwise.
-    //!
-    bool connect(QString inDeviceId);
-    //!
-    //! \brief disconnect Disconnect the previously connected MIDI input device.
-    //!
-    void disconnect();
+	//! \brief connect Connect to the MIDI input device specified by
+	//! <tt>inDeviceId</tt>.
+	//! \param inDeviceId The device ID, as returned by QMidiIn::devices.
+	//! \return \c true if the connection was successful, \c false otherwise.
+	bool connect(QString inDeviceId);
+	//! \brief disconnect Disconnect the previously connected MIDI input device.
+	void disconnect();
 
-    //!
-    //! \brief start Starts listening for input from the device.
-    //!
-    void start();
-    //!
-    //! \brief stop Stops listening for input from the device.
-    //!
-    void stop();
+	//! \brief start Starts listening for input from the device.
+	void start();
+	//! \brief stop Stops listening for input from the device.
+	void stop();
 
-    //!
-    //! \brief isConnected Returns whether the device is connected or not.
-    //! \return \c true if the input device is connected, \c false otherwise.
-    //!
-    bool isConnected() const { return fConnected; }
-    //!
-    //! \brief deviceId Returns the device ID used with QMidiIn::connect.
-    //! \return The device ID used to connect with.
-    //!
-    QString deviceId() const { return fDeviceId; }
+	//! \brief isConnected Returns whether the device is connected or not.
+	//! \return \c true if the input device is connected, \c false otherwise.
+	bool isConnected() const { return fConnected; }
+	//! \brief deviceId Returns the device ID used with QMidiIn::connect.
+	//! \return The device ID used to connect with.
+	QString deviceId() const { return fDeviceId; }
 
 signals:
-    //!
-    //! \brief midiEvent This signal is emitted when a basic MIDI event is
-    //! received.
-    //!
-    //! You can use QMidiEvent::setMessage for easier handling of the event.
-    //! For example:
-    //! \code{.cpp}
-    //! void MainWindow::onMidiEvent(quint32 message, quint32 timing)
-    //! {
-    //!     QMidiEvent event;
-    //!     event.setMessage(message);
-    //!
-    //!     qDebug() << "received event" << event.type()
-    //!              << "note:" << event.note()
-    //!              << "velocity:" << event.velocity();
-    //! }
-    //! \endcode
-    //! \param message The received MIDI message.
-    //! \param timing Timing information provided by Win32 API.  This parameter
-    //! might be removed from the signal in a future version if it is not
-    //! provided by other platforms.
-    //!
-    void midiEvent(quint32 message, quint32 timing);
-    //!
-    //! \brief midiSysExEvent This signal is emitted when a MIDI System
-    //! Exclusive (SysEx) event is received.
-    //! \param data The received SysEx data, including the SysEx start (0xF0)
-    //! and end bytes (0xF7).
-    //!
-    void midiSysExEvent(QByteArray data);
+	//! \brief midiEvent This signal is emitted when a basic MIDI event is
+	//! received.
+	//!
+	//! You can use QMidiEvent::setMessage for easier handling of the event.
+	//! For example:
+	//! \code{.cpp}
+	//! void MainWindow::onMidiEvent(quint32 message, quint32 timing)
+	//! {
+	//!     QMidiEvent event;
+	//!     event.setMessage(message);
+	//!
+	//!     qDebug() << "received event" << event.type()
+	//!              << "note:" << event.note()
+	//!              << "velocity:" << event.velocity();
+	//! }
+	//! \endcode
+	//! \param message The received MIDI message.
+	//! \param timing Timing information provided by Win32 API.  This parameter
+	//! might be removed from the signal in a future version if it is not
+	//! provided by other platforms.
+	void midiEvent(quint32 message, quint32 timing);
+	//! \brief midiSysExEvent This signal is emitted when a MIDI System
+	//! Exclusive (SysEx) event is received.
+	//! \param data The received SysEx data, including the SysEx start (0xF0)
+	//! and end bytes (0xF7).
+	void midiSysExEvent(QByteArray data);
 
 private:
-    QString fDeviceId;
-    NativeMidiInInstances* fMidiPtrs;
-    bool fConnected;
+	QString fDeviceId;
+	NativeMidiInInstances* fMidiPtrs;
+	bool fConnected;
 };

--- a/src/QMidiIn.h
+++ b/src/QMidiIn.h
@@ -14,32 +14,82 @@ class QMidiIn : public QObject
 {
     Q_OBJECT
 public:
-    ///
-    /// \brief devices returns a list of MIDI input devices
-    /// \return QMap<device ID, human-readable device name>
-    ///
+    //!
+    //! \brief Devices returns a list of MIDI input devices.
+    //!
+    //! The items in the returned QMap specify the internal device ID as the
+    //! \c key which needs to be used with QMidiIn::connect, whereas the
+    //! \c value contains the device name that can be used e.g. in a QComboBox.
+    //!
+    //! \return QMap<device ID, human-readable device name>
+    //!
     static QMap<QString /* key */, QString /* name */> devices();
 
     explicit QMidiIn(QObject *parent = nullptr);
     ~QMidiIn();
 
+    //!
+    //! \brief connect Connect to the MIDI input device specified by
+    //! <tt>inDeviceId</tt>.
+    //! \param inDeviceId The device ID, as returned by QMidiIn::devices.
+    //! \return \c true if the connection was successful, \c false otherwise.
+    //!
     bool connect(QString inDeviceId);
+    //!
+    //! \brief disconnect Disconnect the previously connected MIDI input device.
+    //!
     void disconnect();
 
-    ///
-    /// \brief start starts listening for input from the device.
-    ///
+    //!
+    //! \brief start Starts listening for input from the device.
+    //!
     void start();
-    ///
-    /// \brief stop stops listening for input from the device.
-    ///
+    //!
+    //! \brief stop Stops listening for input from the device.
+    //!
     void stop();
 
+    //!
+    //! \brief isConnected Returns whether the device is connected or not.
+    //! \return \c true if the input device is connected, \c false otherwise.
+    //!
     bool isConnected() const { return fConnected; }
+    //!
+    //! \brief deviceId Returns the device ID used with QMidiIn::connect.
+    //! \return The device ID used to connect with.
+    //!
     QString deviceId() const { return fDeviceId; }
 
 signals:
+    //!
+    //! \brief midiEvent This signal is emitted when a basic MIDI event is
+    //! received.
+    //!
+    //! You can use QMidiEvent::setMessage for easier handling of the event.
+    //! For example:
+    //! \code{.cpp}
+    //! void MainWindow::onMidiEvent(quint32 message, quint32 timing)
+    //! {
+    //!     QMidiEvent event;
+    //!     event.setMessage(message);
+    //!
+    //!     qDebug() << "received event" << event.type()
+    //!              << "note:" << event.note()
+    //!              << "velocity:" << event.velocity();
+    //! }
+    //! \endcode
+    //! \param message The received MIDI message.
+    //! \param timing Timing information provided by Win32 API.  This parameter
+    //! might be removed from the signal in a future version if it is not
+    //! provided by other platforms.
+    //!
     void midiEvent(quint32 message, quint32 timing);
+    //!
+    //! \brief midiSysExEvent This signal is emitted when a MIDI System
+    //! Exclusive (SysEx) event is received.
+    //! \param data The received SysEx data, including the SysEx start (0xF0)
+    //! and end bytes (0xF7).
+    //!
     void midiSysExEvent(QByteArray data);
 
 private:

--- a/src/QMidiIn.h
+++ b/src/QMidiIn.h
@@ -40,6 +40,7 @@ public:
 
 signals:
     void midiEvent(quint32 message, quint32 timing);
+    void midiSysExEvent(QByteArray data);
 
 private:
     QString fDeviceId;

--- a/src/QMidiIn.h
+++ b/src/QMidiIn.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Georg Gadinger <nilsding@nilsding.org>
+ * Distributed under the terms of the MIT license.
+ */
+#pragma once
+
+#include <QMap>
+#include <QString>
+#include <QObject>
+
+struct NativeMidiInInstances;
+
+class QMidiIn : public QObject
+{
+    Q_OBJECT
+public:
+    ///
+    /// \brief devices returns a list of MIDI input devices
+    /// \return QMap<device ID, human-readable device name>
+    ///
+    static QMap<QString /* key */, QString /* name */> devices();
+
+    explicit QMidiIn(QObject *parent = nullptr);
+    ~QMidiIn();
+
+    bool connect(QString inDeviceId);
+    void disconnect();
+
+    ///
+    /// \brief start starts listening for input from the device.
+    ///
+    void start();
+    ///
+    /// \brief stop stops listening for input from the device.
+    ///
+    void stop();
+
+    bool isConnected() const { return fConnected; }
+    QString deviceId() const { return fDeviceId; }
+
+signals:
+    void midiEvent(quint32 message, quint32 timing);
+
+private:
+    QString fDeviceId;
+    NativeMidiInInstances* fMidiPtrs;
+    bool fConnected;
+};

--- a/src/QMidiOut.cpp
+++ b/src/QMidiOut.cpp
@@ -21,8 +21,7 @@ QMidiOut::~QMidiOut()
 
 void QMidiOut::sendEvent(const QMidiEvent& e)
 {
-	if (e.type() == QMidiEvent::SysEx)
-	{
+	if (e.type() == QMidiEvent::SysEx) {
 		sendSysEx(e.data());
 		return;
 	}

--- a/src/QMidiOut.cpp
+++ b/src/QMidiOut.cpp
@@ -21,6 +21,12 @@ QMidiOut::~QMidiOut()
 
 void QMidiOut::sendEvent(const QMidiEvent& e)
 {
+	if (e.type() == QMidiEvent::SysEx)
+	{
+		sendSysEx(e.data());
+		return;
+	}
+
 	sendMsg(e.message());
 }
 

--- a/src/QMidiOut.h
+++ b/src/QMidiOut.h
@@ -20,10 +20,8 @@ public:
 	bool connect(QString outDeviceId);
 	void disconnect();
 	void sendMsg(qint32 msg);
-	//!
 	//! \brief sendSysex Sends a raw MIDI System Exclusive (SysEx) message.
 	//! \param data The data to send.
-	//!
 	void sendSysEx(const QByteArray &data);
 
 	void sendEvent(const QMidiEvent& e);
@@ -37,8 +35,8 @@ public:
 	void stopAll();
 	void stopAll(int voice);
 
-    bool isConnected() const { return fConnected; }
-    QString deviceId() const { return fDeviceId; }
+	bool isConnected() const { return fConnected; }
+	QString deviceId() const { return fDeviceId; }
 
 private:
 	QString fDeviceId;

--- a/src/QMidiOut.h
+++ b/src/QMidiOut.h
@@ -20,6 +20,11 @@ public:
 	bool connect(QString outDeviceId);
 	void disconnect();
 	void sendMsg(qint32 msg);
+	//!
+	//! \brief sendSysex Sends a raw MIDI System Exclusive (SysEx) message.
+	//! \param data The data to send.
+	//!
+	void sendSysEx(const QByteArray &data);
 
 	void sendEvent(const QMidiEvent& e);
 	void setInstrument(int voice, int instr);


### PR DESCRIPTION
Here it is, the (at least by myself :P) long-awaited `QMidiIn` class.

I have tried the changes with a (as of yet unreleased and) small test program which interfaces with my Yamaha reface DX where it also retrieves certain data via System Exclusive messages (e.g. the voice name or a change in the FM algorithm used) -- worked fine across all three platforms.