### PR TITLE
Fixed crash on Qt6

### DIFF
--- a/src/QMidiFile.cpp
+++ b/src/QMidiFile.cpp
@@ -409,7 +409,7 @@ QMidiEvent* QMidiFile::createMetaEvent(int track, qint32 tick, int number, QByte
 QMidiEvent* QMidiFile::createTempoEvent(int track, qint32 tick, float tempo)
 {
 	long midi_tempo = 60000000L / tempo;
-	QByteArray buffer;
+	QByteArray buffer(3, 0);
 	buffer[0] = (midi_tempo >> 16) & 0xFF;
 	buffer[1] = (midi_tempo >> 8) & 0xFF;
 	buffer[2] = midi_tempo & 0xFF;
@@ -829,7 +829,7 @@ bool QMidiFile::load(QString filename)
 					case 0xF0:
 					case 0xF7: {
 						int data_length = read_variable_length_quantity(&in) + 1;
-						QByteArray data;
+						QByteArray data(1, 0);
 						data[0] = status;
 						data += in.read(data_length - 1);
 


### PR DESCRIPTION
Hello! The crash is due to a change in the ```QByteArray::operator[]``` in Qt 6:
Qt5: https://doc.qt.io/qt-5/qbytearray.html#operator-5b-5d
Qt6: https://doc.qt.io/qt-6/qbytearray.html#operator-5b-5d