### PR TITLE
Fix MIDI input on CoreMIDI

### DIFF
--- a/src/OS/QMidi_CoreMidi.cpp
+++ b/src/OS/QMidi_CoreMidi.cpp
@@ -155,15 +155,12 @@ static void QMidiInReadProc(const MIDIPacketList *list, void *readProc,
 		UInt16 byteCount = packet->length;
 
 		// Check that MIDIPacket has data in 3-byte groups
-		if (byteCount != 0 && byteCount % 3 == 0)
-		{
+		if (byteCount != 0 && (byteCount % 3) == 0) {
 			// We need to break apart the data into 3-byte messages
 			for (int i = 0; i < byteCount; i += 3) {
-				// Make sure that it's a normal MIDI message. SysSex etc.
+				// Make sure that it's a normal MIDI message. SysEx etc.
 				// are not supported at the moment.
-				if (packet->data[i] < 0xF0
-				&& (packet->data[i] & 0x80) != 0x00)
-				{
+				if ((packet->data[i] < 0xF0) && (packet->data[i] & 0x80)) {
 					quint32 const msg =   (packet->data[i]) 
 										| (packet->data[i + 1] << 8)
 										| (packet->data[i + 2] << 16);

--- a/src/OS/QMidi_CoreMidi.cpp
+++ b/src/OS/QMidi_CoreMidi.cpp
@@ -147,21 +147,30 @@ struct NativeMidiInInstances {
 static void QMidiInReadProc(const MIDIPacketList *list, void *readProc,
 	void *srcConn)
 {
+	Q_UNUSED(srcConn)
 	QMidiIn *midiIn = static_cast<QMidiIn *>(readProc);
 	MIDIPacket *packet = const_cast<MIDIPacket *>(list->packet);
 
 	for (UInt32 index = 0; index < list->numPackets; index++) {
 		UInt16 byteCount = packet->length;
 
-		// Check that the MIDIPacket has data, and is a normal midi
-		// message. (We don't support Sysex, status, etc for CoreMIDI at
-		// the moment.)
-		if (byteCount != 0
-			&& packet->data[0] < 0xF0
-			&& (packet->data[0] & 0x80) != 0x00) {
-			emit(midiIn->midiEvent(*packet->data,
-				packet->timeStamp));
-	    	}
+		// Check that MIDIPacket has data in 3-byte groups
+		if (byteCount != 0 && byteCount % 3 == 0)
+		{
+			// We need to break apart the data into 3-byte messages
+			for (int i = 0; i < byteCount; i += 3) {
+				// Make sure that it's a normal MIDI message. SysSex etc.
+				// are not supported at the moment.
+				if (packet->data[i] < 0xF0
+				&& (packet->data[i] & 0x80) != 0x00)
+				{
+					quint32 const msg =   (packet->data[i]) 
+										| (packet->data[i + 1] << 8)
+										| (packet->data[i + 2] << 16);
+					emit midiIn->midiEvent(msg, packet->timeStamp);
+				}
+			}
+    	}
 
 		packet = MIDIPacketNext(packet);
 	}


### PR DESCRIPTION
The CoreMIDI input code was incorrect - it was only sending the first byte of the entire MIDI packet. Data sent by CoreMIDI is in a packet consisting of multiple MIDI messages. They must be broken up and sent individually to the listener.