### PR TITLE
Included second find_package for Qt again.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOMOC ON)
 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
-#find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
 
 # Common QMidi source files & library
 aux_source_directory("${PROJECT_SOURCE_DIR}/src" SOURCES)


### PR DESCRIPTION
Fixes #32 (Compare https://github.com/waddlesplash/QMidi/issues/32#issuecomment-1081141799, https://github.com/waddlesplash/QMidi/issues/32#issuecomment-1081156149).

The line in question is required to allow CMake to find tools like moc or uic correctly => Uncommented it.